### PR TITLE
Limit default virtual terminals to two

### DIFF
--- a/sbin/init/ttys
+++ b/sbin/init/ttys
@@ -26,15 +26,8 @@
 console	none				unknown	off secure
 #
 ttyv0	"/usr/libexec/getty Pc"		xterm	onifexists secure
-# Virtual terminals
+# Second virtual terminal
 ttyv1	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv2	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv3	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv4	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv5	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv6	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv7	"/usr/libexec/getty Pc"		xterm	onifexists secure
-ttyv8	"/usr/local/bin/xdm -nodaemon"	xterm	off secure
 # Serial terminals
 # The 'dialup' keyword identifies dialin lines to login, fingerd etc.
 ttyu0	"/usr/libexec/getty 3wire"	vt100	onifconsole secure

--- a/share/man/man4/syscons.4
+++ b/share/man/man4/syscons.4
@@ -119,7 +119,7 @@ so that
 will recognize them to be active and run
 .Xr login 1
 to let the user log in to the system.
-By default, only the first eight virtual terminals are activated in
+By default, only the first two virtual terminals are activated in
 .Pa /etc/ttys .
 .Pp
 You press the

--- a/tools/tools/nanobsd/pcengines/Files/etc/ttys
+++ b/tools/tools/nanobsd/pcengines/Files/etc/ttys
@@ -29,15 +29,8 @@
 console	none				unknown	off secure
 #
 ttyv0	"/usr/libexec/getty Pc"		xterm	off  secure
-# Virtual terminals
+# Second virtual terminal
 ttyv1	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv2	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv3	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv4	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv5	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv6	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv7	"/usr/libexec/getty Pc"		xterm	off  secure
-ttyv8	"/usr/local/bin/xdm -nodaemon"	xterm	off secure
 # Serial terminals
 # The 'dialup' keyword identifies dialin lines to login, fingerd etc.
 ttyu0	"/usr/libexec/getty std.9600"	xterm	on secure

--- a/tools/tools/nanobsd/rescue/Files/etc/ttys
+++ b/tools/tools/nanobsd/rescue/Files/etc/ttys
@@ -29,15 +29,8 @@
 console	none				unknown	off secure
 #
 ttyv0	"/usr/libexec/getty Pc"		xterm	on  secure
-# Virtual terminals
+# Second virtual terminal
 ttyv1	"/usr/libexec/getty Pc"		xterm	on  secure
-ttyv2	"/usr/libexec/getty Pc"		xterm	on  secure
-ttyv3	"/usr/libexec/getty Pc"		xterm	off secure
-ttyv4	"/usr/libexec/getty Pc"		xterm	off secure
-ttyv5	"/usr/libexec/getty Pc"		xterm	off secure
-ttyv6	"/usr/libexec/getty Pc"		xterm	off secure
-ttyv7	"/usr/libexec/getty Pc"		xterm	off secure
-ttyv8	"/usr/local/bin/xdm -nodaemon"	xterm	off secure
 # Serial terminals
 # The 'dialup' keyword identifies dialin lines to login, fingerd etc.
 ttyu0	"/usr/libexec/getty std.115200"	xterm-color	on secure


### PR DESCRIPTION
## Summary
- Only enable two virtual terminals by default across system ttys files
- Update documentation to reflect two active VTs

## Testing
- `make -C sbin/init all` *(failed: missing separator)*
- `apt-get update` *(failed: 403 repository not signed)*
- `mandoc -Tlint share/man/man4/syscons.4` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d6bfc21083228247c1a0c9104885