### PR TITLE
Remove residual SLIP support

### DIFF
--- a/bin/stty/print.c
+++ b/bin/stty/print.c
@@ -60,9 +60,6 @@ print(struct termios *tp, struct winsize *wp, int ldisc, enum FMT fmt)
 	/* Line discipline. */
 	if (ldisc != TTYDISC) {
 		switch(ldisc) {
-		case SLIPDISC:
-			cnt += printf("slip disc; ");
-			break;
 		case PPPDISC:
 			cnt += printf("ppp disc; ");
 			break;

--- a/lib/libc/net/getnameinfo.c
+++ b/lib/libc/net/getnameinfo.c
@@ -485,7 +485,6 @@ getnameinfo_link(const struct afd *afd,
 	 * IFT_GIF	(net/if_gif.c)
 	 * IFT_LOOP	(net/if_loop.c)
 	 * IFT_PPP	(net/if_tuntap.c)
-	 * IFT_SLIP	(net/if_sl.c, net/if_strip.c)
 	 * IFT_STF	(net/if_stf.c)
 	 * IFT_L2VLAN	(net/if_vlan.c)
 	 * IFT_BRIDGE (net/if_bridge.h>

--- a/sbin/ifconfig/ifconfig.8
+++ b/sbin/ifconfig/ifconfig.8
@@ -892,9 +892,6 @@ with
 Enable special processing of the link level of the interface.
 These three options are interface specific in actual effect, however,
 they are in general used to select special modes of operation.
-An example
-of this is to enable SLIP compression, or to select the connector type
-for some Ethernet cards.
 Refer to the man page for the specific driver
 for more information.
 .Sm off

--- a/share/man/man9/ifnet.9
+++ b/share/man/man9/ifnet.9
@@ -993,8 +993,6 @@ Internet Point-to-Point Protocol
 The loopback
 .Pq Xr lo 4
 interface
-.It Dv IFT_SLIP
-Serial Line IP
 .It Dv IFT_PARA
 Parallel-port IP
 .Pq Dq Tn PLIP

--- a/sys/compat/linux/linux_ioctl.c
+++ b/sys/compat/linux/linux_ioctl.c
@@ -919,12 +919,9 @@ linux_ioctl_termio(struct thread *td, struct linux_ioctl_args *args)
 		case LINUX_N_TTY:
 			line = TTYDISC;
 			break;
-		case LINUX_N_SLIP:
-			line = SLIPDISC;
-			break;
-		case LINUX_N_PPP:
-			line = PPPDISC;
-			break;
+               case LINUX_N_PPP:
+                       line = PPPDISC;
+                       break;
 		default:
 			fdrop(fp, td);
 			return (EINVAL);
@@ -945,12 +942,9 @@ linux_ioctl_termio(struct thread *td, struct linux_ioctl_args *args)
 		case TTYDISC:
 			linux_line = LINUX_N_TTY;
 			break;
-		case SLIPDISC:
-			linux_line = LINUX_N_SLIP;
-			break;
-		case PPPDISC:
-			linux_line = LINUX_N_PPP;
-			break;
+               case PPPDISC:
+                       linux_line = LINUX_N_PPP;
+                       break;
 		default:
 			fdrop(fp, td);
 			return (EINVAL);

--- a/sys/compat/linux/linux_ioctl.h
+++ b/sys/compat/linux/linux_ioctl.h
@@ -414,7 +414,6 @@
 
 /* line disciplines */
 #define	LINUX_N_TTY		0
-#define	LINUX_N_SLIP		1
 #define	LINUX_N_MOUSE		2
 #define	LINUX_N_PPP		3
 

--- a/sys/conf/options
+++ b/sys/conf/options
@@ -473,7 +473,6 @@ ROUTE_MPATH		opt_route.h
 ROUTETABLES		opt_route.h
 FIB_ALGO		opt_route.h
 RSS			opt_rss.h
-SLIP_IFF_OPTS		opt_slip.h
 TCPPCAP		opt_global.h
 SIFTR
 TCP_BLACKBOX		opt_global.h

--- a/sys/net/if_types.h
+++ b/sys/net/if_types.h
@@ -71,7 +71,6 @@ typedef enum {
 	IFT_EON		= 0x19,		/* ISO over IP */
 	IFT_XETHER	= 0x1a,		/* obsolete 3MB experimental ethernet */
 	IFT_NSIP	= 0x1b,		/* XNS over IP */
-	IFT_SLIP	= 0x1c,		/* IP over generic TTY */
 	IFT_ULTRA	= 0x1d,		/* Ultra Technologies */
 	IFT_DS3		= 0x1e,		/* Generic T3 */
 	IFT_SIP		= 0x1f,		/* SMDS */

--- a/sys/netinet/sctp_bsd_addr.c
+++ b/sys/netinet/sctp_bsd_addr.c
@@ -164,8 +164,7 @@ sctp_is_desired_interface_type(struct ifnet *ifn)
 	case IFT_OTHER:
 	case IFT_PPP:
 	case IFT_LOOP:
-	case IFT_SLIP:
-	case IFT_GIF:
+        case IFT_GIF:
 	case IFT_L2VLAN:
 	case IFT_STF:
 	case IFT_IP:

--- a/sys/sys/ttycom.h
+++ b/sys/sys/ttycom.h
@@ -128,7 +128,6 @@
 						/* 124-127 compat */
 
 #define	TTYDISC		0		/* termios tty line discipline */
-#define	SLIPDISC	4		/* serial IP discipline */
 #define	PPPDISC		5		/* PPP discipline */
 #define	NETGRAPHDISC	6		/* Netgraph tty node discipline */
 #define	H4DISC		7		/* Netgraph Bluetooth H4 discipline */

--- a/usr.sbin/bsdconfig/include/network_device.hlp
+++ b/usr.sbin/bsdconfig/include/network_device.hlp
@@ -1,22 +1,9 @@
-You can do network installations over 3 types of communications links:
+You can do network installations over several types of communications links:
 
-        Serial port:    SLIP / PPP
+        Serial port:	PPP
         Parallel port:  PLIP (laplink cable)
         Ethernet:       A standard Ethernet controller (includes some
                         PCMCIA networking cards).
-
-SLIP support is rather primitive and limited primarily to directly
-connected links, such as a serial cable running between a laptop
-computer and another PC.  The link must be hard-wired as the SLIP
-installation doesn't currently offer a dialing capability (that
-facility is offered by the PPP utility, which should be used in
-preference to SLIP whenever possible).  When you choose the SLIP
-option, you'll be given the option of later editing the slattach
-command before it's run on the serial line.  It is expected that
-you'll run slattach (or some equivalent command) on the other end of
-the link at that time and bring up the line.  FreeBSD will then
-install itself at serial speeds of up to 115.2K/baud (the recommended
-speed for a hardwired cable).
 
 If you're using a modem then PPP is almost certainly your only choice.
 Make sure that you have your service provider's information handy as

--- a/usr.sbin/bsdconfig/include/tcp.hlp
+++ b/usr.sbin/bsdconfig/include/tcp.hlp
@@ -2,7 +2,7 @@ This screen allows you to set up your general network parameters
 (hostname, domain name, DNS server, etc) as well as the settings for a
 given interface (which was selected from the menu before this screen).
 
-PLIP/SLIP users - please read through to the end of this doc!
+PLIP users - please read through to the end of this doc!
 
 The "options" field is kind of special (read: a hack :-):
 
@@ -10,7 +10,7 @@ Any valid options to ifconfig can be specified here, so if you need
 to do something "special" to get your interface working, then here
 is the place to do it.
 
-If you're running SLIP or PLIP, you also need to use it for specifying
+If you're running PLIP, you also need to use it for specifying
 the remote end of the link (simply type the foreign IP address in).
 In the specific case where you're running PLIP with a Linux host peer
 rather than a FreeBSD one, you also must add the "-link0" flag after the


### PR DESCRIPTION
## Summary
- drop Serial Line IP line discipline and build options
- prune SLIP handling from Linux ioctl compatibility and userland tools
- update manuals and helper text to reflect SLIP removal

## Testing
- `make -C bin/stty` *(fails: missing separator)*
- `make -C sbin/ifconfig` *(fails: missing separator)*
- `make -C sys/modules/linux` *(fails: missing separator)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68943552819483229aac975723067d8d