### PR TITLE
Remove residual manpath and man.conf references

### DIFF
--- a/ObsoleteFiles.inc
+++ b/ObsoleteFiles.inc
@@ -16108,9 +16108,6 @@ OLD_FILES+=usr/share/man/man9/vm_page_sleep_busy.9.gz
 OLD_FILES+=usr/share/man/man9/taskqueue_find.9.gz
 # 20101011: removed subblock.h from liblzma
 OLD_FILES+=usr/include/lzma/subblock.h
-# 20101002: removed manpath.config
-OLD_FILES+=etc/manpath.config
-OLD_FILES+=usr/share/examples/etc/manpath.config
 # 20100910: renamed sbuf_overflowed to sbuf_error
 OLD_FILES+=usr/share/man/man9/sbuf_overflowed.9.gz
 # 20100815: retired last traces of chooseproc(9)
@@ -19474,15 +19471,12 @@ OLD_FILES+=etc/periodic/weekly/320.whatis
 OLD_FILES+=usr/bin/apropos
 OLD_FILES+=usr/bin/makewhatis
 OLD_FILES+=usr/bin/man
-OLD_FILES+=usr/bin/manpath
 OLD_FILES+=usr/bin/whatis
 OLD_FILES+=usr/libexec/makewhatis.local
 OLD_FILES+=usr/share/man/man1/apropos.1.gz
 OLD_FILES+=usr/share/man/man1/makewhatis.1.gz
 OLD_FILES+=usr/share/man/man1/man.1.gz
-OLD_FILES+=usr/share/man/man1/manpath.1.gz
 OLD_FILES+=usr/share/man/man1/whatis.1.gz
-OLD_FILES+=usr/share/man/man5/man.conf.5.gz
 OLD_FILES+=usr/share/man/man8/makewhatis.local.8.gz
 OLD_FILES+=usr/share/man/whatis
 OLD_FILES+=usr/share/openssl/man/whatis

--- a/contrib/file/magic/Magdir/archive
+++ b/contrib/file/magic/Magdir/archive
@@ -8,7 +8,7 @@
 
 # POSIX tar archives
 # URL: https://en.wikipedia.org/wiki/Tar_(computing)
-# Reference: https://www.freebsd.org/cgi/man.cgi?query=tar&sektion=5&manpath=FreeBSD+8-current
+# Reference: https://www.freebsd.org/cgi/man.cgi?query=tar&sektion=5
 # header mainly padded with nul bytes
 500	quad		0		
 !:strength /2

--- a/crypto/heimdal/configure
+++ b/crypto/heimdal/configure
@@ -23533,11 +23533,7 @@ $as_echo_n "checking extension of pre-formatted manual pages... " >&6; }
 if test "${ac_cv_sys_catman_ext+set}" = set; then :
   $as_echo_n "(cached) " >&6
 else
-  if grep _suffix /etc/man.conf > /dev/null 2>&1; then
-	ac_cv_sys_catman_ext=0
-else
-	ac_cv_sys_catman_ext=number
-fi
+  ac_cv_sys_catman_ext=number
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_catman_ext" >&5

--- a/crypto/openssh/openssh.xml.in
+++ b/crypto/openssh/openssh.xml.in
@@ -82,8 +82,7 @@
             <documentation>
                 <manpage
                     title='sshd'
-                    section='1M'
-                    manpath='@prefix@/man'/>
+                    section='1M'/>
             </documentation>
         </template>
     </service>

--- a/lib/libutil/login.conf.5
+++ b/lib/libutil/login.conf.5
@@ -240,7 +240,6 @@ directory of the user.
 .Xr maclabel 7 .
 .It "lang	string		Set $LANG environment variable to the specified value."
 .It "mail	string		Set $MAIL environment variable to the specified value."
-.It "manpath	path		Default search path for manpages."
 .It "nocheckmail	bool	false	Display mail status at login."
 .It "nologin	file		If the file exists it will be displayed and"
 the login session will be terminated.

--- a/lib/libutil/login_class.3
+++ b/lib/libutil/login_class.3
@@ -135,13 +135,12 @@ Class capability tags used:
 umask
 .Ed
 .It LOGIN_SETPATH
-Set the "path" and "manpath" environment variables based on values
+Set the "path" environment variable based on values
 in the user or system login class database.
-Class capability tags used with the corresponding environment
-variables set:
+Class capability tag used with the corresponding environment
+variable set:
 .Bd -literal
 path          PATH
-manpath       MANPATH
 .Ed
 .It LOGIN_SETENV
 Set various environment variables based on values in the user or

--- a/lib/libutil/login_class.c
+++ b/lib/libutil/login_class.c
@@ -126,7 +126,6 @@ static struct login_vars {
 } pathvars[] = {
     { "path",           "PATH",       NULL, 1},
     { "cdpath",         "CDPATH",     NULL, 1},
-    { "manpath",        "MANPATH",    NULL, 1},
     { NULL,             NULL,         NULL, 0}
 }, envars[] = {
     { "lang",           "LANG",       NULL, 1},

--- a/share/doc/smm/01.setup/3.t
+++ b/share/doc/smm/01.setup/3.t
@@ -625,7 +625,6 @@ _	_	_
 	/etc/csh.logout	system-wide csh(1) logout file
 	/etc/disklabels	directory for saving disklabels
 	/etc/exports	NFS list of export permissions
-	/etc/man.conf	lists directories searched by \fIman\fP\|(1)
 	/etc/mtree	directory for local mtree files; see mtree(8)
 	/etc/netgroup	NFS group list used in \f(CW/etc/exports\fP
 	/etc/pwd.db	non-secure hashed user data base file

--- a/share/doc/smm/01.setup/6.t
+++ b/share/doc/smm/01.setup/6.t
@@ -519,8 +519,7 @@ Manual pages for local commands should be installed in
 The
 .Xr man (1)
 command automatically finds manual pages placed in
-/usr/local/man/cat[1-8] to encourage this practice (see
-.Xr man.conf (5)).
+/usr/local/man/cat[1-8] to encourage this practice.
 .Sh 2 "Accounting"
 .PP
 UNIX optionally records two kinds of accounting information:

--- a/share/doc/smm/01.setup/spell.ok
+++ b/share/doc/smm/01.setup/spell.ok
@@ -366,7 +366,6 @@ maillog.5
 maillog.6
 maillog.7
 makefiles
-man.conf
 man0
 manl
 master.passwd

--- a/usr.bin/indent/tests/comments.0
+++ b/usr.bin/indent/tests/comments.0
@@ -10,7 +10,7 @@ void t(void) {
 	/*
 	 * Old indent wrapped the URL near where this sentence ends.
 	 *
-	 * https://www.freebsd.org/cgi/man.cgi?query=indent&search=0&sektion=0&manpath=FreeBSD+12-current&arch=default&format=html
+         * https://www.freebsd.org/cgi/man.cgi?query=indent&search=0&sektion=0&arch=default&format=html
 	 */
 	 
 	/*

--- a/usr.bin/indent/tests/comments.0.stdout
+++ b/usr.bin/indent/tests/comments.0.stdout
@@ -12,7 +12,7 @@ t(void)
 	/*
 	 * Old indent wrapped the URL near where this sentence ends.
 	 *
-	 * https://www.freebsd.org/cgi/man.cgi?query=indent&search=0&sektion=0&manpath=FreeBSD+12-current&arch=default&format=html
+         * https://www.freebsd.org/cgi/man.cgi?query=indent&search=0&sektion=0&arch=default&format=html
 	 */
 
 	/*

--- a/usr.bin/login/login.conf
+++ b/usr.bin/login/login.conf
@@ -133,7 +133,6 @@ russian|Russian Users Accounts:\
 #	:setenv=BLOCKSIZE=K:\
 #	:mail=/var/mail/$:\
 #	:path=~/bin /bin /usr/bin /usr/local/bin:\
-#	:manpath=/usr/share/man /usr/local/man:\
 #	:nologin=/var/run/nologin:\
 #	:cputime=1h30m:\
 #	:datasize=8M:\
@@ -157,7 +156,6 @@ russian|Russian Users Accounts:\
 ## users of X (needs more resources!)
 ##
 #xuser:\
-#	:manpath=/usr/share/man /usr/local/man:\
 #	:cputime=4h:\
 #	:datasize=12M:\
 #	:vmemoryuse=infinity:\

--- a/usr.bin/whereis/pathnames.h
+++ b/usr.bin/whereis/pathnames.h
@@ -43,8 +43,6 @@
 /* Each subdirectory of PATH_PORTS will be appended to PATH_SOURCES. */
 #define PATH_PORTS "/usr/ports"
 
-/* How to query the current manpath. */
-#define MANPATHCMD "manpath -q"
 
 /* How to obtain the location of manpages, and how to match this result. */
 #define MANWHEREISCMD "man -S1:8:6 -w %s 2>/dev/null"

--- a/usr.bin/whereis/whereis.c
+++ b/usr.bin/whereis/whereis.c
@@ -289,21 +289,14 @@ defaults(void)
 		}
 	}
 
-	/* -m defaults to $(manpath) */
-	if (!mandirs) {
-		if ((p = popen(MANPATHCMD, "r")) == NULL)
-			err(EX_OSERR, "cannot execute manpath command");
-		if (fgets(buf, BUFSIZ - 1, p) == NULL ||
-		    pclose(p))
-			err(EX_OSERR, "error processing manpath results");
-		if ((b = strchr(buf, '\n')) != NULL)
-			*b = '\0';
-		b = strdup(buf);
-		if (b == NULL)
-			abort();
-		nele = 0;
-		decolonify(b, &mandirs, &nele);
-	}
+       /* -m defaults to $MANPATH if set */
+       if (!mandirs && (cp = getenv("MANPATH")) != NULL) {
+               b = strdup(cp);
+               if (b == NULL)
+                       abort();
+               nele = 0;
+               decolonify(b, &mandirs, &nele);
+       }
 
 	/* -s defaults to precompiled list, plus subdirs of /usr/ports */
 	if (!sourcedirs) {


### PR DESCRIPTION
## Summary
- purge sample `manpath` settings from login configuration examples and documentation
- drop `manpath` capability from libutil and adjust `whereis` to use `$MANPATH`
- remove legacy `manpath`/`man.conf` references from build scripts and docs

## Testing
- `cc -Wall -Wextra -Iusr.bin/whereis usr.bin/whereis/whereis.c -c -o /tmp/whereis.o` *(missing FreeBSD headers)*
- `apt-get update` *(403 errors, unable to install bmake)*

------
https://chatgpt.com/codex/tasks/task_e_6894e9967e9483229a1d4065eac601be