### PR TITLE
Skip mandoc-based manpage builds in imported components

### DIFF
--- a/contrib/libfido2/man/CMakeLists.txt
+++ b/contrib/libfido2/man/CMakeLists.txt
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 find_program(MANDOC_PATH mandoc)
+if(NOT MANDOC_PATH)
+    message(STATUS "mandoc not found; skipping manual pages")
+    return()
+endif()
 find_program(GZIP_PATH gzip)
 
 message(STATUS "MANDOC_PATH: ${MANDOC_PATH}")

--- a/crypto/openssh/configure.ac
+++ b/crypto/openssh/configure.ac
@@ -67,14 +67,10 @@ AC_SUBST([TEST_SHELL], [sh])
 
 dnl select manpage formatter to be used to build "cat" format pages.
 if test "x$MANDOC" != "x" ; then
-	MANFMT="$MANDOC"
-elif test "x$NROFF" != "x" ; then
-	MANFMT="$NROFF -mandoc"
-elif test "x$GROFF" != "x" ; then
-	MANFMT="$GROFF -mandoc -Tascii"
+        MANFMT="$MANDOC"
 else
-	AC_MSG_WARN([no manpage formatter found])
-	MANFMT="false"
+        AC_MSG_WARN([mandoc not found; disabling manpage generation])
+        MANFMT="false"
 fi
 AC_SUBST([MANFMT])
 


### PR DESCRIPTION
## Summary
- Avoid building libfido2 manual pages when `mandoc` is unavailable
- Disable OpenSSH manpage generation without `mandoc`

## Testing
- `cmake .` in `contrib/libfido2/man`
- `make` in `contrib/libfido2/man`
- `./configure` in `crypto/openssh` *(fails: cannot find input file: `config.h.in`)*

------
https://chatgpt.com/codex/tasks/task_e_68956f762ee083228a26dbf46149b162