### PR TITLE
Remove fortune from userland build targets

### DIFF
--- a/share/man/man6/intro.6
+++ b/share/man/man6/intro.6
@@ -46,7 +46,6 @@ location of games
 .Xr intro 1 ,
 .Xr banner 6 ,
 .Xr caesar 6 ,
-.Xr fortune 6 ,
 .Xr grdc 6 ,
 .Xr morse 6 ,
 .Xr number 6 ,

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -197,7 +197,6 @@ SUBDIR.${MK_FILE}+=	file
 SUBDIR.${MK_FTP}+=	ftp
 SUBDIR.${MK_GAMES}+=	caesar
 SUBDIR.${MK_GAMES}+=	factor
-SUBDIR.${MK_GAMES}+=	fortune
 SUBDIR.${MK_GAMES}+=	grdc
 SUBDIR.${MK_GAMES}+=	morse
 SUBDIR.${MK_GAMES}+=	number

--- a/usr.bin/fortune/Makefile
+++ b/usr.bin/fortune/Makefile
@@ -1,4 +1,4 @@
-SUBDIR=	fortune strfile datfiles unstr
+SUBDIR=	strfile datfiles unstr
 
 SUBDIR_DEPEND_datfiles=	strfile
 


### PR DESCRIPTION
### Motivation
- Remove the legacy `fortune` command from the default `usr.bin` games build and update the games intro manpage to reflect that it is no longer part of the standard userland install.

### Description
- Delete the `SUBDIR.${MK_GAMES}+=	fortune` entry in `usr.bin/Makefile`, stop descending into the `fortune` program directory by changing `usr.bin/fortune/Makefile` to `SUBDIR=	strfile datfiles unstr`, and remove the `fortune(6)` cross-reference from `share/man/man6/intro.6`.

### Testing
- Verified the repository diff shows the intended changes using `git diff` which succeeded; `rg` scans for remaining `SUBDIR`/`SUBDIR.${MK_GAMES}` entries referencing `fortune` returned no matches; an attempt to use `make -V` to query bmake-style variables failed because the environment provides GNU make which does not support `-V`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14d41b995c83229e003c5a8280d5d2)