### PR TITLE
Remove telnet and libtelnet from base build targets

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -234,7 +234,6 @@ SUBDIR.${MK_PF}+=	libpfctl
 SUBDIR.${MK_PMC}+=	libpmc libpmcstat
 SUBDIR.${MK_RADIUS_SUPPORT}+=	libradius
 SUBDIR.${MK_SENDMAIL}+=	libmilter libsm libsmdb libsmutil
-SUBDIR.${MK_TELNET}+=	libtelnet
 SUBDIR.${MK_SOUND}+=	libmixer
 SUBDIR.${MK_CUSE}.${MK_SOUND}+=	libsamplerate virtual_oss
 SUBDIR.${MK_TESTS_SUPPORT}+=	atf

--- a/secure/Makefile
+++ b/secure/Makefile
@@ -9,9 +9,8 @@ SUBDIR.${MK_TESTS}+= tests
 SUBDIR.${MK_CAROOT}+= caroot
 
 # These are the programs which depend on crypto, but not Kerberos.
-SPROGS=	lib/libfetch lib/libpam lib/libradius lib/libtelnet	\
-	bin/ed libexec/telnetd usr.bin/fetch usr.bin/telnet	\
-	usr.sbin/ppp usr.sbin/tcpdump/tcpdump
+SPROGS=	lib/libfetch lib/libpam lib/libradius	\
+	bin/ed usr.bin/fetch usr.sbin/ppp usr.sbin/tcpdump/tcpdump
 .if ${MK_SENDMAIL} != "no"
 SPROGS+=usr.sbin/sendmail
 .endif

--- a/share/man/man5/src.conf.5
+++ b/share/man/man5/src.conf.5
@@ -1770,10 +1770,6 @@ Do not build and install
 .Pa /bin/csh
 (which is
 .Xr tcsh 1 ) .
-.It Va WITHOUT_TELNET
-Do not build
-.Xr telnet 1
-and related programs.
 .It Va WITHOUT_TESTS
 Do not build nor install the
 .Fx

--- a/tools/build/mk/OptionalObsoleteFiles.inc
+++ b/tools/build/mk/OptionalObsoleteFiles.inc
@@ -7712,10 +7712,11 @@ OLD_FILES+=usr/share/nls/uk_UA.KOI8-U/tcsh.cat
 OLD_FILES+=usr/share/nls/uk_UA.UTF-8/tcsh.cat
 .endif
 
-.if ${MK_TELNET} == no
 OLD_FILES+=usr/bin/telnet
 OLD_FILES+=usr/share/man/man1/telnet.1.gz
-.endif
+OLD_FILES+=usr/lib/libtelnet.a
+OLD_FILES+=usr/lib/libtelnet_p.a
+OLD_FILES+=usr/libdata/pkgconfig/libtelnet.pc
 
 .if ${MK_TESTS} == yes
 OLD_FILES+=usr/bin/atf-sh

--- a/usr.bin/Makefile
+++ b/usr.bin/Makefile
@@ -237,7 +237,6 @@ SUBDIR.${MK_QUOTAS}+=	quota
 SUBDIR.${MK_SENDMAIL}+=	vacation
 SUBDIR.${MK_SOUND}+=	beep
 SUBDIR.${MK_SOUND}+=	mididump
-SUBDIR.${MK_TELNET}+=	telnet
 SUBDIR.${MK_TESTS_SUPPORT}+=	kyua
 SUBDIR.${MK_TESTS}+=	tests
 SUBDIR.${MK_TEXTPROC}+=	ul


### PR DESCRIPTION
### Motivation
- Remove the base-system telnet client, telnetd server, and the libtelnet library from the set of components built and installed as part of the base tree, and mark their installed artifacts as obsolete.
- Avoid keeping a selectable `WITHOUT_TELNET` build option and related documentation now that telnet is no longer provided by default.

### Description
- Deleted the `SUBDIR.${MK_TELNET}+=	telnet` entry from `usr.bin/Makefile` so the telnet client is not built as part of `usr.bin`.
- Deleted the `SUBDIR.${MK_TELNET}+=	libtelnet` entry from `lib/Makefile` so `libtelnet` is not built in base.
- Removed telnet-related entries from `secure/Makefile` `SPROGS` so `libtelnet`, `libexec/telnetd`, and `usr.bin/telnet` are no longer included in the secure rebuild list.
- Removed the `WITHOUT_TELNET` stanza from `share/man/man5/src.conf.5` and added telnet/libtelnet installed artifacts to `tools/build/mk/OptionalObsoleteFiles.inc` so those files are treated as obsolete removals.

### Testing
- Ran repository scans (`rg`) to locate telnet-related references and verify affected files, and those searches returned expected locations before changes (success).
- Applied the edits with a scripted edit (`python`) and reviewed changes with `git diff -- <files>`, which showed the intended modifications (success).
- Verified working tree state with `git status --short` and committed the change with message `Remove base-system telnet components from build`, and the commit completed successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f9825734832288603a17feb15ff7)