### PR TITLE
build: gate PAM build/link dependencies on MK_PAM

### DIFF
--- a/Makefile.inc1
+++ b/Makefile.inc1
@@ -3433,7 +3433,10 @@ _generic_libs+= ${_DIR}
 .endif
 .endfor
 
-lib/libtacplus__L: lib/libmd__L lib/libpam/libpam__L
+lib/libtacplus__L: lib/libmd__L
+.if ${MK_PAM} != "no"
+lib/libtacplus__L: lib/libpam/libpam__L
+.endif
 lib/libxo__L: lib/libutil__L
 
 .if ${MK_CDDL} != "no"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -80,7 +80,6 @@ SUBDIR=	${SUBDIR_BOOTSTRAP} \
 	libnv \
 	libnvmf \
 	libopenbsd \
-	libpam \
 	libpathconv \
 	libpcap \
 	libpjdlog \
@@ -205,6 +204,7 @@ SUBDIR.${MK_EFI}+=	libefivar
 SUBDIR.${MK_GOOGLETEST}+=	googletest
 SUBDIR.${MK_NETGRAPH}+=	libnetgraph
 SUBDIR.${MK_NIS}+=	libypclnt
+SUBDIR.${MK_PAM}+=	libpam
 
 .if ${MACHINE_CPUARCH} == "i386" || ${MACHINE_CPUARCH} == "amd64"
 _libvgl=	libvgl

--- a/lib/libtacplus/Makefile
+++ b/lib/libtacplus/Makefile
@@ -27,7 +27,11 @@ LIB=		tacplus
 SRCS=		taclib.c
 INCS=		taclib.h
 CFLAGS+=	-Wall
-LIBADD=		md pam
+LIBADD=		md
+
+.if ${MK_PAM} != "no"
+LIBADD+=		pam
+.endif
 SHLIB_MAJOR=	5
 
 MAN=		libtacplus.3


### PR DESCRIPTION
### Motivation

- Allow building the tree without PAM by removing unconditional build/link edges to the PAM library and making PAM-dependent pieces conditional on `MK_PAM`.

### Description

- Remove `libpam` from the unconditional `SUBDIR` list in `lib/Makefile` and add it under `SUBDIR.${MK_PAM}` so `libpam` is only built when `MK_PAM` is enabled.
- Change `lib/libtacplus/Makefile` so `LIBADD` always contains `md` and appends `pam` only when `MK_PAM != "no"` (`LIBADD+= pam` gated by `MK_PAM`).
- Update `Makefile.inc1` to make the `lib/libpam/libpam__L` dependency for `lib/libtacplus__L` conditional on `MK_PAM` instead of being unconditional.

### Testing

- Ran repository inspections and diffs: `rg`/`sed`/`git diff` to verify occurrences and the produced diffs, and the outputs matched the intended edits (succeeded).
- Committed the changes with `git commit -m "build: gate PAM library dependencies behind MK_PAM"` which completed successfully (`741395456`).
- Printed file excerpts with `nl`/`sed` to confirm `SUBDIR.${MK_PAM}` and conditional `LIBADD`/dependency lines are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1564d124688322860274cb0a69caac)