### PR TITLE
build: remove sendmail as a source build option

### DIFF
--- a/share/man/man5/src.conf.5
+++ b/share/man/man5/src.conf.5
@@ -1238,8 +1238,6 @@ When set, it enforces these options:
 .Va WITHOUT_DMAGENT
 .It
 .Va WITHOUT_MAILWRAPPER
-.It
-.Va WITHOUT_SENDMAIL
 .El
 .It Va WITHOUT_MAILWRAPPER
 Do not build the
@@ -1634,10 +1632,6 @@ Disable support in the kernel for the
 .Xr sctp 4
 Stream Control Transmission Protocol
 loadable kernel module.
-.It Va WITHOUT_SENDMAIL
-Do not build
-.Xr sendmail 8
-and related programs.
 .It Va WITHOUT_SERVICESDB
 Do not install
 .Pa /var/db/services.db .

--- a/share/mk/src.opts.mk
+++ b/share/mk/src.opts.mk
@@ -164,7 +164,6 @@ __DEFAULT_YES_OPTIONS = \
     RBOOTD \
     RESCUE \
     ROUTED \
-    SENDMAIL \
     SERVICESDB \
     SETUID_LOGIN \
     SHAREDOCS \
@@ -388,6 +387,9 @@ BROKEN_OPTIONS+=BHYVE_SNAPSHOT
 
 .include <bsd.mkopt.mk>
 
+# Sendmail is no longer a build option.
+MK_SENDMAIL:=	no
+
 #
 # Force some options off if their dependencies are off.
 # Order is somewhat important.
@@ -434,7 +436,6 @@ MK_CTF:=	no
 
 .if ${MK_MAIL} == "no"
 MK_MAILWRAPPER:= no
-MK_SENDMAIL:=	no
 MK_DMAGENT:=	no
 .endif
 


### PR DESCRIPTION
### Motivation
- Sendmail should no longer be built from src or exposed as a configurable source option, so disable it in the src build system and update docs to reflect that decision.

### Description
- Removed `SENDMAIL` from the `__DEFAULT_YES_OPTIONS` list in `share/mk/src.opts.mk` so it is not selected by default.
- Hard-wired `MK_SENDMAIL:=	no` in `share/mk/src.opts.mk` immediately after the `bsd.mkopt.mk` include to make sendmail always disabled in src builds.
- Removed the conditional assignment of `MK_SENDMAIL` under the `MK_MAIL == no` block to avoid redundant settings.
- Updated `share/man/man5/src.conf.5` to remove `WITHOUT_SENDMAIL` references from the `WITHOUT_MAIL` enforced list and to drop the standalone `WITHOUT_SENDMAIL` documentation entry.

### Testing
- Searched the tree with `rg -n "SENDMAIL|MK_SENDMAIL|WITHOUT_SENDMAIL"` to locate and verify affected lines, which succeeded.
- Inspected file regions with `sed -n` to confirm the edits applied to the intended locations, which succeeded.
- Applied the edits via a Python script and re-validated the changes with further `rg`/`sed` checks, which all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1568a41624832289ab492b78560c7d)