### PR TITLE
Fix secure cleandir SPROGS continuation

### DIFF
--- a/secure/Makefile
+++ b/secure/Makefile
@@ -10,6 +10,7 @@ SUBDIR.${MK_CAROOT}+= caroot
 
 # These are the programs which depend on crypto, but not Kerberos.
 SPROGS=	lib/libfetch lib/libpam lib/libradius	\
+	bin/ed usr.bin/fetch usr.sbin/tcpdump/tcpdump
 .if ${MK_SENDMAIL} != "no"
 SPROGS+=usr.sbin/sendmail
 .endif


### PR DESCRIPTION
### Motivation
- A trailing backslash on the `SPROGS` assignment in `secure/Makefile` caused the following `.if ${MK_SENDMAIL}` directive to be treated as part of the variable continuation, producing an `if-less endif` parse error during `cleandir`/`buildworld`.

### Description
- Restore the missing continuation line entries by adding `bin/ed usr.bin/fetch usr.sbin/tcpdump/tcpdump` to the `SPROGS` continuation so the `.if`/`.endif` conditional is parsed correctly.

### Testing
- Ran `git diff --check` which reported no issues and the change was committed successfully.
- Ran a Python continuation sanity check script that verifies no make directives are hidden by a trailing backslash and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bb3de3d2483229c4fd087d9ca176f)