### PR TITLE
Gate pam_zfs_key on MK_PAM and fix Makefile include path

### DIFF
--- a/cddl/lib/Makefile
+++ b/cddl/lib/Makefile
@@ -26,7 +26,9 @@ SUBDIR.${MK_ZFS}+= \
 	libzpool \
 	libzutil
 
-SUBDIR.${MK_ZFS}.${MK_OPENSSL} = pam_zfs_key
+.if ${MK_ZFS} == "yes" && ${MK_OPENSSL} == "yes" && ${MK_PAM} == "yes"
+SUBDIR+=	pam_zfs_key
+.endif
 
 SUBDIR_DEPEND_libavl=		libspl
 SUBDIR_DEPEND_libctf=		libspl

--- a/cddl/lib/pam_zfs_key/Makefile
+++ b/cddl/lib/pam_zfs_key/Makefile
@@ -26,5 +26,5 @@ CFLAGS+= -include ${SRCTOP}/sys/modules/zfs/zfs_config.h
 CFLAGS+= -I${SRCTOP}/sys/contrib/openzfs/include/os/freebsd/zfs
 CFLAGS+= -DRUNSTATEDIR=\"/var/run\"
 
-.include "../../lib/libpam/modules/Makefile.inc"
+.include "${SRCTOP}/lib/libpam/modules/Makefile.inc"
 .include <bsd.lib.mk>


### PR DESCRIPTION
### Motivation
- Prevent the build from descending into the PAM module when PAM is disabled and avoid a hidden cleandir failure caused by a cddl-relative include resolving under `cddl/lib` instead of the source root.

### Description
- Require `MK_PAM` in addition to `MK_ZFS` and `MK_OPENSSL` before adding `pam_zfs_key` to `SUBDIR` by updating `cddl/lib/Makefile` so the PAM module is not visited for WITHOUT_PAM builds.
- Change the include in `cddl/lib/pam_zfs_key/Makefile` from a cddl-relative path to `"${SRCTOP}/lib/libpam/modules/Makefile.inc"` so the libpam module makefile is resolved from the repository root and real cleandir failures are visible.

### Testing
- Ran `git diff --check` to validate no whitespace/conflict issues and it passed.
- Ran `bmake -m /workspace/freebsd-src/share/mk -C cddl/lib -V SUBDIR` with `MK_ZFS=yes MK_OPENSSL=yes MK_PAM=no` and the PAM module was not descended into (success).
- Ran `bmake -m /workspace/freebsd-src/share/mk -C cddl/lib -V SUBDIR` with `MK_ZFS=yes MK_OPENSSL=yes MK_PAM=yes` and `pam_zfs_key` appears as expected in `SUBDIR` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bb5941f248322956f5309709e3378)